### PR TITLE
Update tcmu

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 16313cd078f9d6697e6c3a67da3732df7a8e81dbb11a1b14e342fdbec68c2cb7
-updated: 2017-06-11T10:37:16.27709842+09:00
+hash: d9f6986b2e7ed5f4eb2d76ba370d3820cf7689b348cfe7db8b37a9fbd2ecdc48
+updated: 2017-06-12T12:15:20.426573709+09:00
 imports:
 - name: github.com/alternative-storage/go-tcmu
   version: 5db4f4011c3aa62b8a1436c86e373a014b8317a0
@@ -31,8 +31,6 @@ imports:
   - dbus
   - journal
   - unit
-- name: github.com/coreos/go-tcmu
-  version: a6fc46a3b7d2cf28ecdf7b797241b1bf6723459d
 - name: github.com/coreos/pkg
   version: 3ac0863d7acf3bc44daf49afef8919af12f704ef
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -44,5 +44,5 @@ import:
   - http2/hpack
   - internal/timeseries
 - package: google.golang.org/grpc
-- package: github.com/coreos/go-tcmu
+- package: github.com/alternative-storage/go-tcmu
 - package: github.com/lpabon/godbc

--- a/internal/tcmu/connect.go
+++ b/internal/tcmu/connect.go
@@ -22,6 +22,11 @@ func ConnectAndServe(f *block.BlockFile, name string, closer chan bool) error {
 		OUI:      "000000",
 		VendorID: tcmu.GenerateSerial(name),
 	}
+	// TODO(nak3): Scale up NBD by handling multiple requests.
+	// Requires thread-safety across the block.BlockFile/torus.File
+	//n := runtime.GOMAXPROCS(0) - 1
+	n := 1
+
 	h := &tcmu.SCSIHandler{
 		HBA:        30,
 		LUN:        0,
@@ -37,11 +42,11 @@ func ConnectAndServe(f *block.BlockFile, name string, closer chan bool) error {
 				file: f,
 				name: name,
 				inq: &tcmu.InquiryInfo{
-					VendorID:   "CoreOS",
+					VendorID:   "AlternativeStorage",
 					ProductID:  "TorusBlk",
 					ProductRev: "0001",
 				},
-			}, 1),
+			}, n),
 	}
 	d, err := tcmu.OpenTCMUDevice(devPath, h)
 	if err != nil {


### PR DESCRIPTION
This patch contains:
- remove old go-tcmu package from glide.
- add comment about tcmu's multi thread.