### PR TITLE
cache: put cache data after writing the data successfully

### DIFF
--- a/distributor/storage.go
+++ b/distributor/storage.go
@@ -181,7 +181,11 @@ func (d *Distributor) WriteBlock(ctx context.Context, i torus.BlockRef, data []b
 	if len(peers.Peers) == 0 {
 		return ErrNoPeersBlock
 	}
-	d.readCache.Put(string(i.ToBytes()), data)
+	defer func() {
+		if err == nil {
+			d.readCache.Put(string(i.ToBytes()), data)
+		}
+	}()
 	switch d.getWriteFromServer() {
 	case torus.WriteLocal:
 		err = d.blocks.WriteBlock(ctx, i, data)


### PR DESCRIPTION
cache: put cache data after writing the data successfully

This patch changes the cache data to put after writing the data to local or peers successfully.
As current code put the cache before writing the data, it causes conflict when the writing the data failed.