### PR TITLE
prometheus: move promDistBlockPeerFailures to readFromPeer()

### DIFF
--- a/distributor/storage.go
+++ b/distributor/storage.go
@@ -100,7 +100,6 @@ func (d *Distributor) readSequential(ctx context.Context, i torus.BlockRef, peer
 		// If this peer didn't have it, continue
 		if err == torus.ErrBlockUnavailable || err == torus.ErrNoPeer {
 			clog.Warningf("block %s from %s failed, trying next peer", i, p)
-			promDistBlockPeerFailures.WithLabelValues(p).Inc()
 			continue
 		}
 
@@ -159,6 +158,7 @@ func (d *Distributor) readFromPeer(ctx context.Context, i torus.BlockRef, peer s
 		promDistBlockPeerHits.WithLabelValues(peer).Inc()
 		return blk, nil
 	}
+	promDistBlockPeerFailures.WithLabelValues(peer).Inc()
 	return nil, err
 }
 


### PR DESCRIPTION
prometheus: move promDistBlockPeerFailures to readFromPeer()

ReadLevel doesn't increment the promDistBlockPeerFailures when we set
ReadSpread in current code. Since GetBlock() for remote peers are
called in readFromPeer, this patch moves promDistBlockPeerFailures
incrementation to readFromPeer()