### PR TITLE
[experimental] integrate badger kv database for backend storage

### DIFF
--- a/cmd/torusd/main.go
+++ b/cmd/torusd/main.go
@@ -40,6 +40,7 @@ var (
 	peerAddress string
 	sizeStr     string
 	debugInit   bool
+	kvStore     bool
 	autojoin    bool
 	logpkg      string
 	cfg         torus.Config
@@ -64,6 +65,7 @@ var rootCommand = &cobra.Command{
 
 func init() {
 	rootCommand.PersistentFlags().StringVarP(&blockDevice, "block-device", "", "", "Path to a torus formatted block device")
+	rootCommand.PersistentFlags().BoolVarP(&kvStore, "kvstore", "", false, "Use kv store for backend storage")
 	rootCommand.PersistentFlags().StringVarP(&dataDir, "data-dir", "", "torus-data", "Path to the data directory")
 	rootCommand.PersistentFlags().BoolVarP(&debug, "debug", "", false, "Turn on debug output")
 	rootCommand.PersistentFlags().BoolVarP(&debugInit, "debug-init", "", false, "Run a default init for the MDS if one doesn't exist")
@@ -159,6 +161,10 @@ func runServer(cmd *cobra.Command, args []string) error {
 	switch {
 	case cfg.MetadataAddress == "":
 		srv, err = torus.NewServer(cfg, "temp", "mfile")
+	case kvStore:
+		srv, err = torus.NewServer(cfg, "etcd", "badger")
+	case blockDevice != "":
+		srv, err = torus.NewServer(cfg, "etcd", "block_device")
 	case debugInit:
 		err = torus.InitMDS("etcd", cfg, torus.GlobalMetadata{
 			BlockSize:        512 * 1024,
@@ -172,8 +178,6 @@ func runServer(cmd *cobra.Command, args []string) error {
 			}
 		}
 		fallthrough
-	case blockDevice != "":
-		srv, err = torus.NewServer(cfg, "etcd", "block_device")
 	default:
 		srv, err = torus.NewServer(cfg, "etcd", "mfile")
 	}
@@ -209,7 +213,8 @@ func runServer(cmd *cobra.Command, args []string) error {
 		for _ = range signalChan {
 			fmt.Println("\nReceived an interrupt, stopping services...")
 			close(mainClose)
-			os.Exit(0)
+			// return here to call defer srv.Close()
+			return
 		}
 	}()
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,12 @@
-hash: da7792839b9e11d41554dd51029399c1bd178f3bd7363692a2cb746aa0073531
-updated: 2017-06-14T21:25:28.399459906+09:00
+hash: 299b36d23deab966579d2efc5e012dacef0a30d4826328a4f170fa0d7185fd4c
+updated: 2017-08-19T19:11:18.967081111+09:00
 imports:
 - name: github.com/alternative-storage/go-tcmu
   version: 5db4f4011c3aa62b8a1436c86e373a014b8317a0
   subpackages:
   - scsi
+- name: github.com/AndreasBriese/bbloom
+  version: 28f7e881ca57bc00e028f9ede9f0d9104cfeef5e
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
   subpackages:
@@ -40,6 +42,13 @@ imports:
   - progressutil
 - name: github.com/DeanThompson/ginpprof
   version: 18e555cdf1a9504a2fb2a42c112c7e4a79fc3853
+- name: github.com/dgraph-io/badger
+  version: fb35250eb8faec89c1aa5734914cb39e275f27ed
+  subpackages:
+  - protos
+  - skl
+  - table
+  - "y"
 - name: github.com/dustin/go-humanize
   version: 88e58c26e9fe8ac578a0d76a68e32838acf17a8d
 - name: github.com/glycerine/go-unsnap-stream
@@ -95,6 +104,8 @@ imports:
   version: a97ce2ca70fa5a848076093f05e639a89ca34d06
 - name: github.com/philhofer/fwd
   version: 98c11a7a6ec829d672b03833c3d69a7fae1ca972
+- name: github.com/pkg/errors
+  version: c605e284fe17294bda444b34710735b29d1a9d90
 - name: github.com/prometheus/client_golang
   version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:
@@ -156,7 +167,7 @@ imports:
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
-  version: dfe83d419c9403b40b19d08cdba2afec27b002f7
+  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
   repo: https://go.googlesource.com/net
   subpackages:
   - bpf

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,6 @@
 package: github.com/alternative-storage/torus
 import:
+- package: github.com/dgraph-io/badger
 - package: github.com/DeanThompson/ginpprof
 - package: github.com/RoaringBitmap/roaring
 - package: github.com/barakmich/mmap-go

--- a/internal/tcmu/connect.go
+++ b/internal/tcmu/connect.go
@@ -2,6 +2,7 @@ package torustcmu
 
 import (
 	"fmt"
+	//	"runtime"
 
 	"github.com/alternative-storage/go-tcmu"
 	"github.com/alternative-storage/go-tcmu/scsi"
@@ -24,7 +25,7 @@ func ConnectAndServe(f *block.BlockFile, name string, closer chan bool) error {
 	}
 	// TODO(nak3): Scale up NBD by handling multiple requests.
 	// Requires thread-safety across the block.BlockFile/torus.File
-	//n := runtime.GOMAXPROCS(0) - 1
+	// n := runtime.GOMAXPROCS(0) - 1
 	n := 1
 
 	h := &tcmu.SCSIHandler{

--- a/storage/badger.go
+++ b/storage/badger.go
@@ -1,0 +1,122 @@
+package storage
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/alternative-storage/torus"
+	"github.com/dgraph-io/badger"
+)
+
+var _ torus.BlockStore = &badgerBlock{}
+
+func init() {
+	torus.RegisterBlockStore("badger", openBadgerStorage)
+}
+
+func openBadgerStorage(name string, cfg torus.Config, gmd torus.GlobalMetadata) (torus.BlockStore, error) {
+	nBlocks := cfg.StorageSize / gmd.BlockSize
+	promBlocksAvail.WithLabelValues(name).Set(float64(nBlocks))
+
+	opt := badger.DefaultOptions
+	opt.Dir = cfg.DataDir
+	opt.ValueDir = cfg.DataDir
+
+	open, err := badger.NewKV(&opt)
+	if err != nil {
+		return nil, err
+	}
+	return &badgerBlock{
+		nBlocks:   nBlocks,
+		name:      name,
+		blockSize: gmd.BlockSize,
+		kv:        open,
+	}, nil
+}
+
+type badgerBlock struct {
+	closed    bool
+	name      string
+	blockSize uint64
+	nBlocks   uint64
+	kv        *badger.KV
+}
+
+func (m *badgerBlock) Kind() string { return "badger" }
+func (m *badgerBlock) Flush() error { return nil }
+func (m *badgerBlock) Close() error {
+	if m.kv != nil {
+		return m.kv.Close()
+	}
+	return nil
+}
+
+func (m *badgerBlock) HasBlock(_ context.Context, s torus.BlockRef) (bool, error) {
+	return m.kv.Exists(s.ToBytes())
+}
+
+func (m *badgerBlock) GetBlock(_ context.Context, s torus.BlockRef) ([]byte, error) {
+	var item badger.KVItem
+	if err := m.kv.Get(s.ToBytes(), &item); err != nil {
+		return nil, err
+	}
+	return item.Value(), nil
+}
+
+func (m *badgerBlock) WriteBlock(_ context.Context, s torus.BlockRef, data []byte) error {
+	if m.kv == nil {
+		promBlockWritesFailed.WithLabelValues(m.name).Inc()
+		return torus.ErrClosed
+	}
+	// TODO: consider CompareAndSet
+	if err := m.kv.Set(s.ToBytes(), data, 0x00); err != nil {
+		return err
+	}
+
+	// promBlocks.WithLabelValues(m.name).Set(float64(len(t.store)))
+	promBlocksWritten.WithLabelValues(m.name).Inc()
+
+	return nil
+}
+
+// TODO: WriteBuf is necessary for tdp
+func (m *badgerBlock) WriteBuf(_ context.Context, s torus.BlockRef) ([]byte, error) { return nil, nil }
+
+func (m *badgerBlock) DeleteBlock(_ context.Context, s torus.BlockRef) error {
+	return m.kv.Delete(s.ToBytes())
+}
+
+func (m *badgerBlock) BlockIterator() torus.BlockIterator {
+	opt := badger.DefaultIteratorOptions
+	itr := m.kv.NewIterator(opt)
+	return &badgerIterator{
+		itr: itr,
+	}
+}
+
+type badgerIterator struct {
+	itr *badger.Iterator
+}
+
+func (i *badgerIterator) Err() error { return nil }
+
+func (i *badgerIterator) Next() bool {
+	if !i.itr.Valid() {
+		return false
+	}
+	i.itr.Next()
+	return true
+}
+func (i *badgerIterator) BlockRef() torus.BlockRef {
+	return torus.BlockRefFromBytes(i.itr.Item().Key())
+}
+
+func (i *badgerIterator) Close() error {
+	if i.itr != nil {
+		i.itr.Close()
+	}
+	return nil
+}
+
+func (m *badgerBlock) NumBlocks() uint64  { return m.nBlocks }
+func (m *badgerBlock) BlockSize() uint64  { return m.blockSize }
+func (m *badgerBlock) UsedBlocks() uint64 { return 0 }


### PR DESCRIPTION
[experimental] integrate badger kv database for backend storage

Currently torus backend storage (a.k.a torusd) has two outstanding challenges.

  1. performance issue (especially https://github.com/alternative-storage/torus/issues/18)
  2. lock intensive codes

Here, this patch integrated
[badger](https://github.com/dgraph-io/badger) LSM-tree based kv store
and sees if I could tackle these issues.